### PR TITLE
Setting up proper pixelRatio for the threejs renderer.

### DIFF
--- a/index.js
+++ b/index.js
@@ -357,6 +357,7 @@ function pixel(graph, options) {
     renderer = new THREE.WebGLRenderer(glOptions);
 
     renderer.setClearColor(options.clearColor, options.clearAlpha);
+    if (window && window.devicePixelRatio) renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(container.clientWidth, container.clientHeight);
     container.appendChild(renderer.domElement);
 


### PR DESCRIPTION
At the moment Three.js renderer used by ngraph does not use the correct pixel ratio therefore graphs look blurry in hi-dpi devices. This fix sets up the correct pixel ratio by using `window.devicePixelRatio` if available.