### PR TITLE
Fixed bug in mouse coordinates.

### DIFF
--- a/lib/hitTest.js
+++ b/lib/hitTest.js
@@ -126,11 +126,11 @@ function createHitTest(domElement) {
 
   function setMouseCoordinates(e) {
     var boundingRect = domElement.getBoundingClientRect();
-    mouse.x = ((e.pageX - boundingRect.left) / boundingRect.width) * 2 - 1;
-    mouse.y = -((e.pageY - boundingRect.top) / boundingRect.height) * 2 + 1;
+    mouse.x = ((e.clientX - boundingRect.left) / boundingRect.width) * 2 - 1;
+    mouse.y = -((e.clientY - boundingRect.top) / boundingRect.height) * 2 + 1;
 
-    domMouse.x = e.clientX;
-    domMouse.y = e.clientY;
+    domMouse.x = e.pageX;
+    domMouse.y = e.pageY;
   }
 
   function update(scene, camera) {


### PR DESCRIPTION
hey there, I found and fixed a small bug in the setting of mouse coordinates when doing hittests. This allows for correct behaviour when embedding in e.g. a bigger document where there is scrolling and the container is moving around the screen.